### PR TITLE
feat: circular icon, notifications, settings, UI redesign (#1-#5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,18 +18,21 @@ Every feature issue follows this sequence:
 
 1. **Test case selection** — Define tests for the logic being changed/added before writing code
 2. **Implementation** — Write feature code and test code together
-3. **`swift test`** — All tests must pass (currently 60+)
+3. **`swift test`** — All tests must pass (currently 83)
 4. **Commit/push** — Reference issue number in commit message
 
 ## Architecture
 
 | File | Role |
 |------|------|
-| `CursorBarApp.swift` | App entry, MenuBarExtra |
-| `MenuBarView.swift` | Popover UI |
-| `UsageViewModel.swift` | State management, auto-refresh |
+| `CursorBarApp.swift` | App entry, MenuBarExtra + Settings scene |
+| `MenuBarView.swift` | Popover UI (4-section layout) |
+| `UsageViewModel.swift` | State management, auto-refresh, settings persistence |
 | `CursorAPIClient.swift` | API calls (actor, ephemeral URLSession) |
 | `UsageModels.swift` | Codable models + display model |
+| `CircularProgressIcon.swift` | Menu bar progress ring icon + color thresholds |
+| `NotificationManager.swift` | Usage threshold notifications (UserNotifications) |
+| `SettingsView.swift` | Settings window UI (refresh, notifications, display) |
 | `LoginWindow.swift` | WKWebView login + domain whitelist |
 | `KeychainStore.swift` | Credential storage (Data Protection Keychain) |
 | `LogRedactor.swift` | Sensitive data redaction for logs |
@@ -37,7 +40,7 @@ Every feature issue follows this sequence:
 ## Conventions
 
 - Swift 6 strict concurrency: `@MainActor`, `actor`, `Sendable`
-- Zero external dependencies — macOS SDK only (`Foundation`, `Security`, `WebKit`, `SwiftUI`)
+- Zero external dependencies — macOS SDK only (`Foundation`, `Security`, `WebKit`, `SwiftUI`, `UserNotifications`)
 - `URLSessionConfiguration.ephemeral` — no disk cache
 - Keychain with `kSecUseDataProtectionKeychain: true` — no permission prompts
 - WebView domain whitelist enforced in `decidePolicyFor`

--- a/Sources/CursorBar/CircularProgressIcon.swift
+++ b/Sources/CursorBar/CircularProgressIcon.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+import AppKit
+
+// MARK: - Progress Level
+
+enum ProgressLevel: Sendable, Equatable {
+    case normal
+    case warning
+    case critical
+
+    var color: Color {
+        switch self {
+        case .normal: .green
+        case .warning: .yellow
+        case .critical: .red
+        }
+    }
+}
+
+// MARK: - Circular Progress Icon
+
+enum CircularProgressIcon {
+    static func level(for percent: Double) -> ProgressLevel {
+        if percent >= 90 { return .critical }
+        if percent >= 70 { return .warning }
+        return .normal
+    }
+
+    static func menuBarImage(percent: Double, size: CGFloat = 18) -> NSImage {
+        let image = NSImage(size: NSSize(width: size, height: size), flipped: false) { rect in
+            guard let ctx = NSGraphicsContext.current?.cgContext else { return false }
+
+            let lineWidth: CGFloat = 1.5
+            let center = CGPoint(x: rect.midX, y: rect.midY)
+            let radius = (min(rect.width, rect.height) - lineWidth * 2) / 2
+
+            // Track
+            ctx.setStrokeColor(NSColor.gray.withAlphaComponent(0.3).cgColor)
+            ctx.setLineWidth(lineWidth)
+            ctx.addEllipse(in: CGRect(x: center.x - radius, y: center.y - radius,
+                                       width: radius * 2, height: radius * 2))
+            ctx.strokePath()
+
+            // Progress arc
+            let progress = min(max(percent / 100.0, 0), 1.0)
+            if progress > 0 {
+                let nsColor = NSColor(level(for: percent).color)
+                ctx.setStrokeColor(nsColor.cgColor)
+                ctx.setLineWidth(lineWidth)
+                ctx.setLineCap(.round)
+
+                // Start at 12 o'clock, go clockwise
+                let startAngle = CGFloat.pi / 2
+                let endAngle = startAngle - (2 * .pi * progress)
+                ctx.addArc(center: center, radius: radius,
+                           startAngle: startAngle, endAngle: endAngle, clockwise: true)
+                ctx.strokePath()
+            }
+
+            return true
+        }
+        image.isTemplate = false
+        return image
+    }
+}

--- a/Sources/CursorBar/CursorBarApp.swift
+++ b/Sources/CursorBar/CursorBarApp.swift
@@ -6,7 +6,7 @@ struct CursorBarApp: App {
     @State private var loginWindow: LoginWindow?
 
     var body: some Scene {
-        MenuBarExtra("CursorBar", systemImage: "chart.bar.fill") {
+        MenuBarExtra {
             MenuBarView(
                 viewModel: viewModel,
                 onLogin: { showLogin() },
@@ -15,8 +15,18 @@ struct CursorBarApp: App {
             .onAppear {
                 viewModel.checkExistingSession()
             }
+        } label: {
+            let percent = viewModel.usageData?.percentUsed ?? 0
+            Image(nsImage: CircularProgressIcon.menuBarImage(percent: percent))
+            if viewModel.showMenuBarText, let data = viewModel.usageData {
+                Text(data.usageText)
+            }
         }
         .menuBarExtraStyle(.window)
+
+        Settings {
+            SettingsView(viewModel: viewModel)
+        }
     }
 
     private func showLogin() {

--- a/Sources/CursorBar/MenuBarView.swift
+++ b/Sources/CursorBar/MenuBarView.swift
@@ -2,13 +2,17 @@ import SwiftUI
 
 struct MenuBarView: View {
     @Bindable var viewModel: UsageViewModel
+    @Environment(\.openSettings) private var openSettings
     var onLogin: () -> Void
     var onQuit: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
+            // Section 1: User info + Usage (or status)
             if let data = viewModel.usageData {
-                usageContent(data)
+                userInfoSection(data)
+                Divider()
+                usageSection(data)
             } else if viewModel.isLoading {
                 Text("Loading...")
                     .foregroundStyle(.secondary)
@@ -23,31 +27,42 @@ struct MenuBarView: View {
 
             Divider()
 
-            // Refresh interval picker
-            Menu("Refresh: \(viewModel.refreshInterval.label)") {
-                ForEach(RefreshInterval.allCases, id: \.rawValue) { interval in
-                    Button(interval.label) {
-                        viewModel.setRefreshInterval(interval)
+            // Section 2: Quick settings
+            HStack {
+                Image(systemName: "timer")
+                    .foregroundStyle(.secondary)
+                Menu("Refresh: \(viewModel.refreshInterval.label)") {
+                    ForEach(RefreshInterval.allCases, id: \.rawValue) { interval in
+                        Button(interval.label) {
+                            viewModel.setRefreshInterval(interval)
+                        }
                     }
                 }
+                Spacer()
+                Button {
+                    openSettings()
+                    NSApp.activate(ignoringOtherApps: true)
+                } label: {
+                    Image(systemName: "gear")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
             }
 
             Divider()
+
+            // Section 3: Actions
+            Button("Open Dashboard") {
+                if let url = URL(string: "https://www.cursor.com/dashboard?tab=usage") {
+                    NSWorkspace.shared.open(url)
+                }
+            }
 
             switch viewModel.authState {
             case .loggedOut, .loginRequired:
                 Button("Log In...") { onLogin() }
             case .loggedIn:
-                Button("Refresh Now") {
-                    Task { await viewModel.refresh() }
-                }
                 Button("Log Out") { viewModel.logout() }
-            }
-
-            Button("Open Dashboard") {
-                if let url = URL(string: "https://www.cursor.com/dashboard") {
-                    NSWorkspace.shared.open(url)
-                }
             }
 
             Divider()
@@ -57,9 +72,10 @@ struct MenuBarView: View {
         .padding(8)
     }
 
+    // MARK: - User Info Section
+
     @ViewBuilder
-    private func usageContent(_ data: UsageDisplayData) -> some View {
-        // Name & email
+    private func userInfoSection(_ data: UsageDisplayData) -> some View {
         HStack {
             Text(data.name)
                 .font(.headline)
@@ -68,25 +84,42 @@ struct MenuBarView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
+    }
 
-        // Request usage
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("Requests")
-                    .font(.subheadline)
-                Spacer()
-                Text(data.usageText)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+    // MARK: - Usage Section
+
+    @ViewBuilder
+    private func usageSection(_ data: UsageDisplayData) -> some View {
+        // Requests + inline refresh
+        HStack {
+            Text("Requests")
+                .font(.subheadline)
+            Spacer()
+            Text(data.usageText)
+                .font(.subheadline)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+            if viewModel.authState == .loggedIn {
+                Button {
+                    Task { await viewModel.refresh() }
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .disabled(viewModel.isLoading)
             }
+        }
+
+        // Progress bar + percent
+        HStack(spacing: 8) {
             ProgressView(value: min(data.percentUsed / 100.0, 1.0))
-                .tint(data.percentUsed > 90 ? .red : .accentColor)
-            HStack {
-                Spacer()
-                Text(data.percentText + " used")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+                .tint(CircularProgressIcon.level(for: data.percentUsed).color)
+            Text(data.percentText)
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(.secondary)
+                .frame(width: 32, alignment: .trailing)
         }
 
         // Reset date

--- a/Sources/CursorBar/NotificationManager.swift
+++ b/Sources/CursorBar/NotificationManager.swift
@@ -1,0 +1,95 @@
+import UserNotifications
+
+// MARK: - Threshold Evaluation
+
+enum ThresholdLevel: Sendable, Equatable {
+    case none
+    case warning
+    case critical
+}
+
+// MARK: - Notification Manager
+
+@MainActor
+final class NotificationManager {
+    private(set) var notifiedThresholds: Set<Int> = []
+
+    nonisolated static func evaluateThreshold(
+        percentUsed: Double,
+        warningThreshold: Int,
+        criticalThreshold: Int,
+        notifiedThresholds: Set<Int>
+    ) -> ThresholdLevel {
+        if percentUsed >= Double(criticalThreshold)
+            && !notifiedThresholds.contains(criticalThreshold)
+        {
+            return .critical
+        }
+        if percentUsed >= Double(warningThreshold)
+            && !notifiedThresholds.contains(warningThreshold)
+        {
+            return .warning
+        }
+        return .none
+    }
+
+    func checkAndNotify(
+        percentUsed: Double,
+        warningThreshold: Int,
+        criticalThreshold: Int,
+        enabled: Bool
+    ) async {
+        guard enabled else { return }
+
+        let level = Self.evaluateThreshold(
+            percentUsed: percentUsed,
+            warningThreshold: warningThreshold,
+            criticalThreshold: criticalThreshold,
+            notifiedThresholds: notifiedThresholds
+        )
+
+        switch level {
+        case .none:
+            break
+        case .warning:
+            await sendNotification(
+                title: "Cursor Usage Warning",
+                body: "Usage has reached \(Int(percentUsed))% of your limit."
+            )
+            notifiedThresholds.insert(warningThreshold)
+        case .critical:
+            await sendNotification(
+                title: "Cursor Usage Critical",
+                body: "Usage has reached \(Int(percentUsed))% of your limit."
+            )
+            notifiedThresholds.insert(criticalThreshold)
+        }
+    }
+
+    func resetNotifications() {
+        notifiedThresholds.removeAll()
+    }
+
+    private func sendNotification(title: String, body: String) async {
+        let center = UNUserNotificationCenter.current()
+        do {
+            let granted = try await center.requestAuthorization(options: [.alert, .sound])
+            guard granted else { return }
+
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = .default
+
+            let request = UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil
+            )
+            try await center.add(request)
+            Log.info("Notification sent: \(title)")
+        } catch {
+            Log.error("Notification failed: \(error)")
+        }
+    }
+}

--- a/Sources/CursorBar/SettingsView.swift
+++ b/Sources/CursorBar/SettingsView.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Bindable var viewModel: UsageViewModel
+
+    var body: some View {
+        Form {
+            Section("Refresh") {
+                Picker("Interval", selection: refreshIntervalBinding) {
+                    ForEach(RefreshInterval.allCases, id: \.rawValue) { interval in
+                        Text(interval.label).tag(interval)
+                    }
+                }
+            }
+
+            Section("Notifications") {
+                Toggle("Enable usage alerts", isOn: notificationEnabledBinding)
+
+                if viewModel.notificationEnabled {
+                    LabeledContent("Warning") {
+                        Text("\(viewModel.warningThreshold)%")
+                            .monospacedDigit()
+                    }
+                    Slider(value: warningSlider, in: 50...95, step: 5)
+
+                    LabeledContent("Critical") {
+                        Text("\(viewModel.criticalThreshold)%")
+                            .monospacedDigit()
+                    }
+                    Slider(value: criticalSlider, in: 60...100, step: 5)
+                }
+            }
+
+            Section("Menu Bar") {
+                Toggle("Show usage text next to icon", isOn: showMenuBarTextBinding)
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 350, height: 300)
+    }
+
+    // MARK: - Bindings
+
+    private var refreshIntervalBinding: Binding<RefreshInterval> {
+        Binding(
+            get: { viewModel.refreshInterval },
+            set: { viewModel.setRefreshInterval($0) }
+        )
+    }
+
+    private var notificationEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.notificationEnabled },
+            set: { viewModel.setNotificationEnabled($0) }
+        )
+    }
+
+    private var warningSlider: Binding<Double> {
+        Binding(
+            get: { Double(viewModel.warningThreshold) },
+            set: { viewModel.setWarningThreshold(Int($0)) }
+        )
+    }
+
+    private var criticalSlider: Binding<Double> {
+        Binding(
+            get: { Double(viewModel.criticalThreshold) },
+            set: { viewModel.setCriticalThreshold(Int($0)) }
+        )
+    }
+
+    private var showMenuBarTextBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.showMenuBarText },
+            set: { viewModel.setShowMenuBarText($0) }
+        )
+    }
+}

--- a/Sources/CursorBar/UsageViewModel.swift
+++ b/Sources/CursorBar/UsageViewModel.swift
@@ -26,16 +26,36 @@ enum RefreshInterval: Int, CaseIterable {
 @Observable
 @MainActor
 final class UsageViewModel {
+    // MARK: - Auth & Data
+
     var authState: AuthState = .loggedOut
     var usageData: UsageDisplayData?
     var errorMessage: String?
     var isLoading = false
-    private var isRefreshing = false
-    var refreshInterval: RefreshInterval = .fiveMinutes
 
+    // MARK: - Settings
+
+    var refreshInterval: RefreshInterval = .fiveMinutes
+    var notificationEnabled: Bool = true
+    var warningThreshold: Int = 80
+    var criticalThreshold: Int = 90
+    var showMenuBarText: Bool = false
+
+    // MARK: - Private
+
+    private var isRefreshing = false
     private let apiClient = CursorAPIClient()
     private var refreshTask: Task<Void, Never>?
     private var cachedCookieHeader: String?
+    private let notificationManager = NotificationManager()
+
+    // MARK: - Init
+
+    init() {
+        loadSettings()
+    }
+
+    // MARK: - Session
 
     func checkExistingSession() {
         do {
@@ -85,6 +105,16 @@ final class UsageViewModel {
 
             usageData = UsageDisplayData.from(usage: usage, userInfo: userInfo)
             Log.info("Usage data refreshed")
+
+            // Check notification thresholds
+            if let data = usageData {
+                await notificationManager.checkAndNotify(
+                    percentUsed: data.percentUsed,
+                    warningThreshold: warningThreshold,
+                    criticalThreshold: criticalThreshold,
+                    enabled: notificationEnabled
+                )
+            }
         } catch APIError.unauthorized {
             Log.info("Session expired, clearing keychain")
             cachedCookieHeader = nil
@@ -111,13 +141,60 @@ final class UsageViewModel {
         usageData = nil
         errorMessage = nil
         stopAutoRefresh()
+        notificationManager.resetNotifications()
         Log.info("Logged out")
     }
 
+    // MARK: - Settings Setters
+
     func setRefreshInterval(_ interval: RefreshInterval) {
         refreshInterval = interval
+        UserDefaults.standard.set(interval.rawValue, forKey: "refreshIntervalSeconds")
         if authState == .loggedIn {
             startAutoRefresh()
+        }
+    }
+
+    func setNotificationEnabled(_ enabled: Bool) {
+        notificationEnabled = enabled
+        UserDefaults.standard.set(enabled, forKey: "notificationEnabled")
+    }
+
+    func setWarningThreshold(_ value: Int) {
+        warningThreshold = value
+        UserDefaults.standard.set(value, forKey: "warningThreshold")
+    }
+
+    func setCriticalThreshold(_ value: Int) {
+        criticalThreshold = value
+        UserDefaults.standard.set(value, forKey: "criticalThreshold")
+    }
+
+    func setShowMenuBarText(_ show: Bool) {
+        showMenuBarText = show
+        UserDefaults.standard.set(show, forKey: "showMenuBarText")
+    }
+
+    // MARK: - Private
+
+    private func loadSettings() {
+        let defaults = UserDefaults.standard
+        if let raw = defaults.object(forKey: "refreshIntervalSeconds") as? Int,
+           let interval = RefreshInterval(rawValue: raw)
+        {
+            refreshInterval = interval
+        }
+        if let val = defaults.object(forKey: "notificationEnabled") as? Bool {
+            notificationEnabled = val
+        }
+        if let val = defaults.object(forKey: "warningThreshold") as? Int {
+            warningThreshold = val
+        }
+        if let val = defaults.object(forKey: "criticalThreshold") as? Int {
+            criticalThreshold = val
+        }
+        if let val = defaults.object(forKey: "showMenuBarText") as? Bool {
+            showMenuBarText = val
         }
     }
 

--- a/Tests/CursorBarTests/CircularProgressIconTests.swift
+++ b/Tests/CursorBarTests/CircularProgressIconTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import CursorBar
+
+final class CircularProgressIconTests: XCTestCase {
+
+    // MARK: - ProgressLevel
+
+    func testLevelNormalAt0() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 0), .normal)
+    }
+
+    func testLevelNormalAt69() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 69.9), .normal)
+    }
+
+    func testLevelWarningAt70() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 70), .warning)
+    }
+
+    func testLevelWarningAt89() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 89.9), .warning)
+    }
+
+    func testLevelCriticalAt90() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 90), .critical)
+    }
+
+    func testLevelCriticalAt100() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 100), .critical)
+    }
+
+    func testLevelNormalNegative() {
+        XCTAssertEqual(CircularProgressIcon.level(for: -10), .normal)
+    }
+
+    func testLevelCriticalOver100() {
+        XCTAssertEqual(CircularProgressIcon.level(for: 150), .critical)
+    }
+
+    // MARK: - Menu Bar Image
+
+    func testMenuBarImageNotNil() {
+        let image = CircularProgressIcon.menuBarImage(percent: 50)
+        XCTAssertEqual(image.size.width, 18)
+        XCTAssertEqual(image.size.height, 18)
+    }
+
+    func testMenuBarImageZeroPercent() {
+        let image = CircularProgressIcon.menuBarImage(percent: 0)
+        XCTAssertEqual(image.size.width, 18)
+    }
+
+    func testMenuBarImageNotTemplate() {
+        let image = CircularProgressIcon.menuBarImage(percent: 50)
+        XCTAssertFalse(image.isTemplate)
+    }
+}

--- a/Tests/CursorBarTests/NotificationManagerTests.swift
+++ b/Tests/CursorBarTests/NotificationManagerTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import CursorBar
+
+final class NotificationManagerTests: XCTestCase {
+
+    // MARK: - Threshold Evaluation (Pure Logic)
+
+    func testBelowWarningReturnsNone() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 50,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .none)
+    }
+
+    func testAtWarningReturnsWarning() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 80,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .warning)
+    }
+
+    func testAboveWarningBelowCriticalReturnsWarning() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 85,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .warning)
+    }
+
+    func testAtCriticalReturnsCritical() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 90,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .critical)
+    }
+
+    func testAboveCriticalReturnsCritical() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 95,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .critical)
+    }
+
+    func testWarningAlreadyNotifiedReturnsNone() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 85,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: [80]
+        )
+        XCTAssertEqual(result, .none)
+    }
+
+    func testCriticalAlreadyNotifiedReturnsNone() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 95,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: [80, 90]
+        )
+        XCTAssertEqual(result, .none)
+    }
+
+    func testCriticalNotNotifiedButWarningWasReturnsCritical() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 92,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: [80]
+        )
+        XCTAssertEqual(result, .critical)
+    }
+
+    func testJumpPastBothReturnsCritical() {
+        // When usage jumps from below warning to above critical,
+        // critical takes priority
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 95,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .critical)
+    }
+
+    func testCustomThresholds() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 65,
+            warningThreshold: 60,
+            criticalThreshold: 75,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .warning)
+    }
+
+    func testZeroPercentReturnsNone() {
+        let result = NotificationManager.evaluateThreshold(
+            percentUsed: 0,
+            warningThreshold: 80,
+            criticalThreshold: 90,
+            notifiedThresholds: []
+        )
+        XCTAssertEqual(result, .none)
+    }
+
+    // MARK: - NotificationManager State
+
+    @MainActor
+    func testResetClearsNotifiedThresholds() {
+        let manager = NotificationManager()
+        // Simulate having notified
+        Task {
+            await manager.checkAndNotify(
+                percentUsed: 85,
+                warningThreshold: 80,
+                criticalThreshold: 90,
+                enabled: false // disabled to avoid actual notification
+            )
+        }
+        manager.resetNotifications()
+        XCTAssertTrue(manager.notifiedThresholds.isEmpty)
+    }
+}

--- a/docs/test-checklist.md
+++ b/docs/test-checklist.md
@@ -33,6 +33,43 @@ Run through these scenarios after each feature change or before release.
 - [ ] Click "Log Out" → returns to logged-out state
 - [ ] After logout, relaunch → does NOT auto-login (Keychain cleared)
 
+## Menu Bar Icon (#1)
+
+- [ ] Circular progress ring displayed in menu bar (not the old chart.bar.fill)
+- [ ] Empty gray ring when not logged in or loading
+- [ ] Green ring when usage < 70%
+- [ ] Yellow ring when usage 70–89%
+- [ ] Red ring when usage ≥ 90%
+- [ ] "Show usage text" setting OFF → icon only
+- [ ] "Show usage text" setting ON → "189/500" text next to icon
+
+## Notifications (#2)
+
+- [ ] First notification request prompts macOS permission dialog
+- [ ] Warning notification at 80% (default) threshold
+- [ ] Critical notification at 90% (default) threshold
+- [ ] Same threshold does NOT trigger duplicate notification
+- [ ] Notification not sent when disabled in settings
+- [ ] Custom threshold values work (e.g., 60% / 75%)
+
+## Settings (#3)
+
+- [ ] Gear icon in popover opens Settings window
+- [ ] Refresh interval picker persists after app restart
+- [ ] Notification toggle enables/disables alerts
+- [ ] Warning/Critical sliders adjust thresholds
+- [ ] "Show usage text" toggle updates menu bar immediately
+
+## Popover UI (#5)
+
+- [ ] 4-section layout: user info / usage / settings / actions
+- [ ] Inline refresh icon (↻) next to usage instead of "Refresh Now" button
+- [ ] Progress bar and percentage on same row
+- [ ] Progress bar color matches icon colors (green/yellow/red)
+- [ ] "Open Dashboard" links to `?tab=usage`
+- [ ] Timer icon (⏱) next to refresh interval picker
+- [ ] Gear icon opens Settings window
+
 ## Security
 
 - [ ] No Keychain permission prompts during normal use


### PR DESCRIPTION
## Summary

- **#1 Circular progress icon**: Menu bar에 사용량 퍼센트를 원형 프로그레스 링으로 표시 (green ≤70%, yellow 70-90%, red ≥90%). 텍스트 표시 토글 지원.
- **#2 Usage threshold notification**: 사용량 80%/90% 도달 시 macOS 알림 발송. 중복 방지, 커스텀 임계치 지원.
- **#3 Settings UI**: Settings 창 추가 (refresh interval, notification on/off + 임계치, menu bar 표시 형식). UserDefaults 영속화.
- **#4 Open Dashboard → usage tab**: Dashboard URL에 `?tab=usage` 추가.
- **#5 Popover UI/UX redesign**: 4-section 레이아웃 (user info / usage / settings / actions). "Refresh Now" 버튼 → 인라인 ↻ 아이콘. 프로그레스바 색상 아이콘과 통일.

## Test plan

- [x] `swift test` — 83 tests, 0 failures (기존 60 + 신규 23)
- [ ] Manual: 원형 아이콘 색상 변화 확인 (green/yellow/red)
- [ ] Manual: Settings 창 열기 및 설정 변경 후 앱 재시작 시 유지 확인
- [ ] Manual: 알림 권한 요청 및 임계치 도달 시 알림 확인
- [ ] Manual: 팝오버 4-section 레이아웃 및 인라인 새로고침 아이콘 확인
- [ ] Manual: "Open Dashboard" → usage 탭 열림 확인

Closes #1, closes #2, closes #3, closes #4, closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)