### PR TITLE
Show Cursor Models and Other Models usage like the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Two undocumented endpoints used (cookie-based auth, no official schema):
 | `/api/usage-summary` | Primary — billingCycleEnd, plan %, membershipType | USD cents |
 | `/api/usage` | Supplementary — request counts per model | requests |
 | `/api/auth/me` | User info (email, name) | — |
+| `/api/dashboard/get-current-period-usage` | Ultra split quota — Cursor Models / Other Models % | percent |
 
 - `UsageViewModel.refresh()` calls all three in parallel with graceful degradation
 - `/api/usage` uses dynamic key parsing (no hardcoded model names)

--- a/Sources/CursorMeter/CircularProgressIcon.swift
+++ b/Sources/CursorMeter/CircularProgressIcon.swift
@@ -116,13 +116,15 @@ enum CircularProgressIcon {
         return image
     }
 
-    /// Pie chart + percent text as a single NSImage
-    static func menuBarImageWithPercent(percent: Double) -> NSImage {
+    /// Pie chart + percent text as a single NSImage.
+    /// `label` overrides the default rounded `percent` string so split-quota
+    /// plans can show both bucket percents (e.g. "32% · 86%").
+    static func menuBarImageWithPercent(percent: Double, label: String? = nil) -> NSImage {
         let pieSize: CGFloat = 20
         let font = NSFont.monospacedDigitSystemFont(ofSize: 13, weight: .medium)
         let textColor = NSColor.labelColor
 
-        let percentStr = NSAttributedString(string: "\(Int(percent.rounded()))%", attributes: [
+        let percentStr = NSAttributedString(string: label ?? "\(Int(percent.rounded()))%", attributes: [
             .font: font, .foregroundColor: textColor,
         ])
         let textSize = percentStr.size()

--- a/Sources/CursorMeter/CursorAPIClient.swift
+++ b/Sources/CursorMeter/CursorAPIClient.swift
@@ -18,6 +18,7 @@ actor CursorAPIClient {
     private static let filteredUsageEventsURL = URL(string: "https://cursor.com/api/dashboard/get-filtered-usage-events")!
     private static let teamSpendURL = URL(string: "https://cursor.com/api/dashboard/get-team-spend")!
     private static let hardLimitURL = URL(string: "https://cursor.com/api/dashboard/get-hard-limit")!
+    private static let currentPeriodUsageURL = URL(string: "https://cursor.com/api/dashboard/get-current-period-usage")!
 
     private let session: URLSession
 
@@ -114,6 +115,20 @@ actor CursorAPIClient {
             origin: "https://cursor.com"
         )
         return try JSONDecoder().decode(TeamSpendResponse.self, from: data)
+    }
+
+    /// Current-cycle split quota (Cursor Models vs Other Models). Empty body —
+    /// `{"teamId":0}` 400s on personal/Ultra. Same Origin requirement as the
+    /// other dashboard POSTs.
+    func fetchCurrentPeriodUsage(cookieHeader: String) async throws -> CurrentPeriodUsageResponse {
+        let data = try await performRequest(
+            url: Self.currentPeriodUsageURL,
+            cookieHeader: cookieHeader,
+            method: "POST",
+            body: Data("{}".utf8),
+            origin: "https://cursor.com"
+        )
+        return try JSONDecoder().decode(CurrentPeriodUsageResponse.self, from: data)
     }
 
     /// Member-facing monthly spend limit for token-based enterprise contracts.

--- a/Sources/CursorMeter/CursorAppAuthReader.swift
+++ b/Sources/CursorMeter/CursorAppAuthReader.swift
@@ -5,6 +5,23 @@ import SQLite3
 struct IDECredential: Sendable, Equatable {
     let cookieHeader: String   // "WorkosCursorSessionToken=<id>%3A%3A<jwt>"
     let expiresAt: Date
+    /// From `cursorAuth/cachedEmail` or `cursorAuth/email` — used when
+    /// `/api/auth/me` 404s for GitHub-numeric identities.
+    let email: String?
+    /// From `cursorAuth/cachedScopedProfile.displayName`.
+    let name: String?
+
+    init(
+        cookieHeader: String,
+        expiresAt: Date,
+        email: String? = nil,
+        name: String? = nil
+    ) {
+        self.cookieHeader = cookieHeader
+        self.expiresAt = expiresAt
+        self.email = email
+        self.name = name
+    }
 }
 
 /// Reads the Cursor IDE's access token from its local state DB and synthesizes
@@ -51,9 +68,16 @@ struct CursorAppAuthReader: Sendable {
               let userID = Self.userID(fromSub: claims.sub)
         else { return nil }
 
+        let email = Self.readString(db: db, key: "cursorAuth/cachedEmail")
+            ?? Self.readString(db: db, key: "cursorAuth/email")
+        let name = Self.displayName(
+            fromProfileJSON: Self.readString(db: db, key: "cursorAuth/cachedScopedProfile"))
+
         return IDECredential(
             cookieHeader: Self.makeCookieHeader(userID: userID, jwt: jwt),
-            expiresAt: claims.exp
+            expiresAt: claims.exp,
+            email: email,
+            name: name
         )
     }
 
@@ -84,5 +108,31 @@ struct CursorAppAuthReader: Sendable {
 
     nonisolated static func makeCookieHeader(userID: String, jwt: String) -> String {
         "WorkosCursorSessionToken=\(userID)%3A%3A\(jwt)"
+    }
+
+    /// Single-key string read on an already-open handle. Returns nil on
+    /// missing key or empty value. Never logs the value.
+    nonisolated static func readString(db: OpaquePointer?, key: String) -> String? {
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db, "SELECT value FROM ItemTable WHERE key = ?",
+            -1, &stmt, nil) == SQLITE_OK
+        else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        sqlite3_bind_text(stmt, 1, key, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let cString = sqlite3_column_text(stmt, 0)
+        else { return nil }
+        let value = String(cString: cString).trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+        return value.isEmpty ? nil : value
+    }
+
+    nonisolated static func displayName(fromProfileJSON json: String?) -> String? {
+        guard let json, let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let name = object["displayName"] as? String
+        else { return nil }
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }

--- a/Sources/CursorMeter/CursorMeterApp.swift
+++ b/Sources/CursorMeter/CursorMeterApp.swift
@@ -138,18 +138,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSPopoverDelegate, NSW
                 : CircularProgressIcon.idleImage()
         }
         let mode = UsageViewModel.resolvedMenuBarDisplayMode(
-            isPercentOnly: data.isPercentOnly, setting: viewModel.menuBarDisplayMode)
+            isPercentOnly: data.isPercentOnly || data.hasBucketMeters,
+            setting: viewModel.menuBarDisplayMode)
+        let ringPercent = data.menuBarRingPercent
         switch mode {
         case 2:
-            return CircularProgressIcon.menuBarImageWithPercent(percent: data.percentUsed)
+            return CircularProgressIcon.menuBarImageWithPercent(
+                percent: ringPercent,
+                label: data.hasBucketMeters ? data.menuBarBucketText : nil)
         case 1:
             return CircularProgressIcon.menuBarImageWithText(
-                percent: data.percentUsed,
+                percent: ringPercent,
                 usedText: data.menuBarUsedText,
                 limitText: data.menuBarLimitText
             )
         default:
-            return CircularProgressIcon.menuBarImage(percent: data.percentUsed)
+            return CircularProgressIcon.menuBarImage(percent: ringPercent)
         }
     }
 

--- a/Sources/CursorMeter/MenuBarView.swift
+++ b/Sources/CursorMeter/MenuBarView.swift
@@ -36,9 +36,17 @@ final class MenuBarPopoverViewController: NSViewController {
     private let usageValueLabel  = NSTextField(labelWithString: "")
     private let refreshButton    = NSButton()
 
-    // Progress row
+    // Progress row (single-meter plans)
+    private let progressRow      = NSStackView()
     private let progressBar      = ColoredProgressBar()
     private let percentLabel     = NSTextField(labelWithString: "")
+
+    // Dual bucket meters (Ultra / split-quota plans)
+    private let bucketMetersStack = NSStackView()
+    private let cursorModelsBar   = ColoredProgressBar()
+    private let otherModelsBar    = ColoredProgressBar()
+    private let cursorModelsPercentLabel = NSTextField(labelWithString: "")
+    private let otherModelsPercentLabel  = NSTextField(labelWithString: "")
 
     // Secondary metric row (hidden when no secondary data). In normal mode shows
     // On-demand; in on-demand mode shows the previous primary (Requests or Plan).
@@ -278,8 +286,7 @@ final class MenuBarPopoverViewController: NSViewController {
 
         dataStack.addArrangedSubview(usageRow)
 
-        // --- Progress bar + percent ---
-        let progressRow = NSStackView()
+        // --- Progress bar + percent (single-meter plans) ---
         progressRow.orientation = .horizontal
         progressRow.spacing = 6
         progressRow.translatesAutoresizingMaskIntoConstraints = false
@@ -298,6 +305,32 @@ final class MenuBarPopoverViewController: NSViewController {
         progressRow.addArrangedSubview(percentLabel)
 
         dataStack.addArrangedSubview(progressRow)
+
+        // --- Dual bucket meters (Cursor Models / Other Models) ---
+        bucketMetersStack.orientation = .vertical
+        bucketMetersStack.alignment = .leading
+        bucketMetersStack.spacing = 10
+        bucketMetersStack.translatesAutoresizingMaskIntoConstraints = false
+        bucketMetersStack.addArrangedSubview(
+            makeBucketMeter(
+                title: "Cursor Models",
+                subtitle: "Includes Cursor Grok and Composer",
+                bar: cursorModelsBar,
+                percentLabel: cursorModelsPercentLabel,
+                barColor: NSColor.systemCyan
+            )
+        )
+        bucketMetersStack.addArrangedSubview(
+            makeBucketMeter(
+                title: "Other Models",
+                subtitle: nil,
+                bar: otherModelsBar,
+                percentLabel: otherModelsPercentLabel,
+                barColor: NSColor.labelColor
+            )
+        )
+        bucketMetersStack.isHidden = true
+        dataStack.addArrangedSubview(bucketMetersStack)
 
         // --- Secondary metric row ---
         secondaryRow.orientation = .horizontal
@@ -500,10 +533,30 @@ final class MenuBarPopoverViewController: NSViewController {
         refreshButton.isEnabled     = !viewModel.isLoading
         refreshButton.isHidden      = (viewModel.authState != .loggedIn)
 
-        // Progress
-        progressBar.progress = min(data.percentUsed / 100.0, 1.0)
-        progressBar.barColor = CircularProgressIcon.tokenColor(for: data.percentUsed)
-        percentLabel.stringValue = data.percentText
+        // Progress: Ultra split-quota plans get the dashboard dual meters;
+        // on-demand mode keeps the single bar so the spend latch stays obvious.
+        if data.hasBucketMeters, !data.isOnDemandActive {
+            progressRow.isHidden = true
+            bucketMetersStack.isHidden = false
+            applyBucketMeter(
+                percent: data.cursorModelsPercent,
+                bar: cursorModelsBar,
+                label: cursorModelsPercentLabel,
+                fallbackColor: NSColor.systemCyan
+            )
+            applyBucketMeter(
+                percent: data.otherModelsPercent,
+                bar: otherModelsBar,
+                label: otherModelsPercentLabel,
+                fallbackColor: NSColor.labelColor
+            )
+        } else {
+            bucketMetersStack.isHidden = true
+            progressRow.isHidden = false
+            progressBar.progress = min(data.percentUsed / 100.0, 1.0)
+            progressBar.barColor = CircularProgressIcon.tokenColor(for: data.percentUsed)
+            percentLabel.stringValue = data.percentText
+        }
 
         // Secondary metric row (label + value vary by mode — see UsageDisplayData)
         if let label = data.secondaryUsageLabel, let value = data.secondaryUsageValue {
@@ -717,6 +770,67 @@ final class MenuBarPopoverViewController: NSViewController {
     }
 
     // MARK: - Factory helpers
+
+    private func makeBucketMeter(
+        title: String,
+        subtitle: String?,
+        bar: ColoredProgressBar,
+        percentLabel: NSTextField,
+        barColor: NSColor
+    ) -> NSView {
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = NSFont.systemFont(ofSize: 11, weight: .medium)
+        titleLabel.textColor = NSColor.labelColor
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleLabel.lineBreakMode = .byTruncatingTail
+
+        percentLabel.font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        percentLabel.textColor = NSColor.secondaryLabelColor
+        percentLabel.alignment = .right
+        percentLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+
+        let header = NSStackView(views: [titleLabel, percentLabel])
+        header.orientation = .horizontal
+        header.spacing = 6
+
+        bar.barColor = barColor
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.heightAnchor.constraint(equalToConstant: 6).isActive = true
+
+        let block = NSStackView()
+        block.orientation = .vertical
+        block.alignment = .leading
+        block.spacing = 3
+        block.translatesAutoresizingMaskIntoConstraints = false
+        block.addArrangedSubview(header)
+        block.addArrangedSubview(bar)
+        header.widthAnchor.constraint(equalTo: block.widthAnchor).isActive = true
+        bar.widthAnchor.constraint(equalTo: block.widthAnchor).isActive = true
+
+        if let subtitle {
+            let caption = NSTextField(wrappingLabelWithString: subtitle)
+            caption.font = NSFont.systemFont(ofSize: 9)
+            caption.textColor = NSColor.tertiaryLabelColor
+            caption.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            block.addArrangedSubview(caption)
+            caption.widthAnchor.constraint(lessThanOrEqualTo: block.widthAnchor).isActive = true
+        }
+
+        return block
+    }
+
+    private func applyBucketMeter(
+        percent: Double?,
+        bar: ColoredProgressBar,
+        label: NSTextField,
+        fallbackColor: NSColor
+    ) {
+        let value = percent ?? 0
+        bar.progress = min(value / 100.0, 1.0)
+        bar.barColor = fallbackColor
+        label.stringValue = "\(Int(value.rounded()))% used"
+    }
 
     private func makeDivider() -> NSBox {
         let box = NSBox()

--- a/Sources/CursorMeter/SettingsAppearanceTabViewController.swift
+++ b/Sources/CursorMeter/SettingsAppearanceTabViewController.swift
@@ -69,6 +69,7 @@ final class SettingsAppearanceTabViewController: NSViewController {
         // The popup reflects the EFFECTIVE mode (None stays None, #105) via
         // the same resolver the status item uses.
         let percentOnly = viewModel.usageData?.isPercentOnly == true
+            || viewModel.usageData?.hasBucketMeters == true
         let ratioIndex = menuBarDisplayPopUp.indexOfItem(withTag: 1)
         if percentOnly {
             if ratioIndex >= 0 { menuBarDisplayPopUp.removeItem(at: ratioIndex) }

--- a/Sources/CursorMeter/UsageModels.swift
+++ b/Sources/CursorMeter/UsageModels.swift
@@ -91,6 +91,41 @@ struct PlanUsage: Codable, Sendable {
     let limit: Int?
     let remaining: Int?
     let totalPercentUsed: Double?
+    /// Cursor Models bucket (Grok / Composer). Present on Ultra and some
+    /// personal plans; sourced from usage-summary or get-current-period-usage.
+    let autoPercentUsed: Double?
+    /// Other Models / API bucket.
+    let apiPercentUsed: Double?
+
+    init(
+        enabled: Bool?,
+        used: Int?,
+        limit: Int?,
+        remaining: Int?,
+        totalPercentUsed: Double?,
+        autoPercentUsed: Double? = nil,
+        apiPercentUsed: Double? = nil
+    ) {
+        self.enabled = enabled
+        self.used = used
+        self.limit = limit
+        self.remaining = remaining
+        self.totalPercentUsed = totalPercentUsed
+        self.autoPercentUsed = autoPercentUsed
+        self.apiPercentUsed = apiPercentUsed
+    }
+}
+
+// MARK: - API Response: /api/dashboard/get-current-period-usage
+
+struct CurrentPeriodUsageResponse: Codable, Sendable {
+    let planUsage: CurrentPeriodPlanUsage?
+}
+
+struct CurrentPeriodPlanUsage: Codable, Sendable {
+    let autoPercentUsed: Double?
+    let apiPercentUsed: Double?
+    let totalPercentUsed: Double?
 }
 
 struct OnDemandUsage: Codable, Sendable {
@@ -151,6 +186,52 @@ struct UsageDisplayData: Sendable {
     let cycleStartDate: Date?
     let resetDate: Date?
 
+    /// Dashboard "Cursor Models" bar (`autoPercentUsed`).
+    let cursorModelsPercent: Double?
+    /// Dashboard "Other Models" bar (`apiPercentUsed`).
+    let otherModelsPercent: Double?
+
+    init(
+        email: String,
+        name: String,
+        membershipType: String?,
+        planUsedCents: Int?,
+        planLimitCents: Int?,
+        serverPercentUsed: Double?,
+        requestsUsed: Int,
+        requestsLimit: Int,
+        onDemandUsedCents: Int?,
+        onDemandLimitCents: Int?,
+        onDemandEnabled: Bool?,
+        isOnDemandActive: Bool,
+        cycleStartDate: Date?,
+        resetDate: Date?,
+        cursorModelsPercent: Double? = nil,
+        otherModelsPercent: Double? = nil
+    ) {
+        self.email = email
+        self.name = name
+        self.membershipType = membershipType
+        self.planUsedCents = planUsedCents
+        self.planLimitCents = planLimitCents
+        self.serverPercentUsed = serverPercentUsed
+        self.requestsUsed = requestsUsed
+        self.requestsLimit = requestsLimit
+        self.onDemandUsedCents = onDemandUsedCents
+        self.onDemandLimitCents = onDemandLimitCents
+        self.onDemandEnabled = onDemandEnabled
+        self.isOnDemandActive = isOnDemandActive
+        self.cycleStartDate = cycleStartDate
+        self.resetDate = resetDate
+        self.cursorModelsPercent = cursorModelsPercent
+        self.otherModelsPercent = otherModelsPercent
+    }
+
+    /// Both dashboard buckets present — popover shows the dual-meter layout.
+    var hasBucketMeters: Bool {
+        cursorModelsPercent != nil && otherModelsPercent != nil
+    }
+
     /// Returns a copy with `isOnDemandActive` overridden. Used by UsageViewModel
     /// to inject the sticky-latched mode after computing it.
     func withOnDemandActive(_ active: Bool) -> UsageDisplayData {
@@ -164,7 +245,9 @@ struct UsageDisplayData: Sendable {
             onDemandEnabled: onDemandEnabled,
             isOnDemandActive: active,
             cycleStartDate: cycleStartDate,
-            resetDate: resetDate
+            resetDate: resetDate,
+            cursorModelsPercent: cursorModelsPercent,
+            otherModelsPercent: otherModelsPercent
         )
     }
 
@@ -183,6 +266,10 @@ struct UsageDisplayData: Sendable {
                   let used = onDemandUsedCents else { return 0 }
             return Double(used) / Double(limit) * 100.0
         }
+        // Ultra / split-quota plans: the ring and notifications follow
+        // `totalPercentUsed`, not cents-used / cents-limit (bonus spend can
+        // push that ratio well over 100% while the dashboard still shows ~40%).
+        if hasBucketMeters, let server = serverPercentUsed { return server }
         if isPercentOnly, let server = serverPercentUsed { return server }
         if isCreditBased {
             guard let limit = planLimitCents, limit > 0, let used = planUsedCents else { return 0 }
@@ -201,6 +288,7 @@ struct UsageDisplayData: Sendable {
         if isOnDemandActive {
             return "\(Self.formatUSD(onDemandUsedCents ?? 0)) / \(Self.formatUSD(onDemandLimitCents ?? 0))"
         }
+        if hasBucketMeters { return otherModelsHeaderText }
         if isPercentOnly { return percentText }
         if isCreditBased {
             return "\(Self.formatUSD(planUsedCents ?? 0)) / \(Self.formatUSD(planLimitCents ?? 0))"
@@ -213,6 +301,7 @@ struct UsageDisplayData: Sendable {
         if isOnDemandActive {
             return Self.formatCompactUSD(onDemandUsedCents ?? 0)
         }
+        if hasBucketMeters { return menuBarBucketText }
         if isPercentOnly { return percentText }
         if isCreditBased {
             return Self.formatCompactUSD(planUsedCents ?? 0)
@@ -224,7 +313,7 @@ struct UsageDisplayData: Sendable {
         if isOnDemandActive {
             return Self.formatCompactUSD(onDemandLimitCents ?? 0)
         }
-        if isPercentOnly { return "" }
+        if hasBucketMeters || isPercentOnly { return "" }
         if isCreditBased {
             return Self.formatCompactUSD(planLimitCents ?? 0)
         }
@@ -233,8 +322,36 @@ struct UsageDisplayData: Sendable {
 
     var usageLabel: String {
         if isOnDemandActive { return "On-demand" }
+        if hasBucketMeters { return cursorModelsHeaderText }
         if isPercentOnly { return "Plan Usage" }
         return isCreditBased ? "Plan Usage" : "Requests"
+    }
+
+    var cursorModelsHeaderText: String {
+        "Cursor \(Self.roundedPercentText(cursorModelsPercent))"
+    }
+
+    var otherModelsHeaderText: String {
+        "Other \(Self.roundedPercentText(otherModelsPercent))"
+    }
+
+    /// Compact dual-percent string for the menu-bar status item.
+    var menuBarBucketText: String {
+        "\(Self.roundedPercentText(cursorModelsPercent)) · \(Self.roundedPercentText(otherModelsPercent))"
+    }
+
+    /// Ring fill when both buckets are shown: the hotter of the two, so an
+    /// 86% Other-Models bar is not hidden behind a 40% combined total.
+    var menuBarRingPercent: Double {
+        if isOnDemandActive { return percentUsed }
+        if hasBucketMeters {
+            return max(cursorModelsPercent ?? 0, otherModelsPercent ?? 0)
+        }
+        return percentUsed
+    }
+
+    nonisolated static func roundedPercentText(_ percent: Double?) -> String {
+        "\(Int((percent ?? 0).rounded()))%"
     }
 
     var hasOnDemand: Bool {
@@ -385,7 +502,8 @@ struct UsageDisplayData: Sendable {
         usage: UsageResponse?,
         userInfo: UserInfoResponse,
         perUserMonthlyLimitDollars: Int? = nil,
-        perUserOnDemandLimitDollars: Int? = nil
+        perUserOnDemandLimitDollars: Int? = nil,
+        period: CurrentPeriodUsageResponse? = nil
     ) -> UsageDisplayData {
         let model = usage?.primaryModel
         let isRequestBased = model?.maxRequestUsage != nil
@@ -433,14 +551,21 @@ struct UsageDisplayData: Sendable {
             onDemandEnabled = onDemand?.enabled
         }
 
+        let periodPlan = period?.planUsage
+        let cursorPercent = periodPlan?.autoPercentUsed ?? plan?.autoPercentUsed
+        let otherPercent = periodPlan?.apiPercentUsed ?? plan?.apiPercentUsed
+        let totalPercent = periodPlan?.totalPercentUsed
+            ?? plan?.totalPercentUsed
+            ?? Self.percent(from: summary.autoModelSelectedDisplayMessage)
+        let buckets = cursorPercent != nil && otherPercent != nil
+
         return UsageDisplayData(
             email: userInfo.email ?? "Unknown",
             name: userInfo.name ?? "Unknown",
             membershipType: summary.membershipType,
             planUsedCents: isRequestBased ? nil : planUsedCents,
             planLimitCents: isRequestBased ? nil : planLimitCents,
-            serverPercentUsed: plan?.totalPercentUsed
-                ?? Self.percent(from: summary.autoModelSelectedDisplayMessage),
+            serverPercentUsed: totalPercent,
             requestsUsed: isRequestBased ? requestCount(model) : 0,
             requestsLimit: isRequestBased ? (model?.maxRequestUsage ?? 0) : 0,
             onDemandUsedCents: onDemandUsedCents,
@@ -448,7 +573,9 @@ struct UsageDisplayData: Sendable {
             onDemandEnabled: onDemandEnabled,
             isOnDemandActive: false,
             cycleStartDate: parseDate(summary.billingCycleStart),
-            resetDate: resetDate
+            resetDate: resetDate,
+            cursorModelsPercent: buckets ? cursorPercent : nil,
+            otherModelsPercent: buckets ? otherPercent : nil
         )
     }
 

--- a/Sources/CursorMeter/UsageViewModel.swift
+++ b/Sources/CursorMeter/UsageViewModel.swift
@@ -548,7 +548,10 @@ final class UsageViewModel {
             setIDEAvailability(ideCredential != nil)
             if let ide = ideCredential {
                 do {
-                    try await runRefreshAttempt(cookieHeader: ide.cookieHeader)
+                    try await runRefreshAttempt(
+                        cookieHeader: ide.cookieHeader,
+                        identityFallback: UserInfoResponse(email: ide.email, name: ide.name)
+                    )
                     authState = .loggedIn
                     activeAuthSource = .cursorIDE
                     return
@@ -591,7 +594,10 @@ final class UsageViewModel {
     /// One credential's full refresh batch (#54): fetch, decode, apply state,
     /// and success-path side effects. Throws instead of handling errors so the
     /// credential chain in refresh() can decide fallback vs terminal handling.
-    private func runRefreshAttempt(cookieHeader: String) async throws {
+    private func runRefreshAttempt(
+        cookieHeader: String,
+        identityFallback: UserInfoResponse = UserInfoResponse(email: nil, name: nil)
+    ) async throws {
         let apiClient = self.apiClient
         // `async let` (not unstructured `Task {}`) keeps the three calls
         // tied to refresh()'s cancellation lifecycle; `capture` turns each
@@ -600,6 +606,7 @@ final class UsageViewModel {
         async let summaryCapture = Self.capture { try await apiClient.fetchUsageSummary(cookieHeader: cookieHeader) }
         async let usageCapture = Self.capture { try await apiClient.fetchUsage(cookieHeader: cookieHeader) }
         async let userInfoCapture = Self.capture { try await apiClient.fetchUserInfo(cookieHeader: cookieHeader) }
+        async let periodCapture = Self.capture { try await apiClient.fetchCurrentPeriodUsage(cookieHeader: cookieHeader) }
 
         // Optimistic weekly fetch — runs in parallel with the primary batch
         // once a prior refresh established the account's weekly fetch shape
@@ -617,6 +624,7 @@ final class UsageViewModel {
         let userInfoRes = await userInfoCapture
         let summaryRes = await summaryCapture
         let usageRes = await usageCapture
+        let periodRes = await periodCapture
 
         // Expiry check runs over ALL results before any decode failure can
         // abort the refresh — the 2026-07-03 incident: /api/auth/me decode
@@ -625,9 +633,24 @@ final class UsageViewModel {
             throw APIError.unauthorized
         }
 
-        let userInfo = try userInfoRes.get()
+        // Identity is optional when usage data is present. GitHub-linked
+        // accounts store `sub` as `github|<numeric>`; `/api/auth/me` 404s
+        // "User not found" for that prefix while usage-summary still 200s.
+        // Failing the whole refresh on that 404 is what showed as
+        // "Server error (404)" with a working session.
         let summary = try? summaryRes.get()
         let usage = try? usageRes.get()
+        let userInfo: UserInfoResponse
+        if case .success(let info) = userInfoRes {
+            userInfo = info
+        } else if summary != nil || usage != nil {
+            userInfo = identityFallback
+            Log.info("auth/me unavailable — using cached identity fallback")
+        } else if case .failure(let error) = userInfoRes {
+            throw error
+        } else {
+            throw APIError.httpError(statusCode: 0)
+        }
 
         // The IDE credential can silently belong to a different account than
         // the previous refresh (#54) — reset per-account state BEFORE applying
@@ -676,7 +699,8 @@ final class UsageViewModel {
             baseData = UsageDisplayData.from(
                 summary: summary, usage: usage, userInfo: userInfo,
                 perUserMonthlyLimitDollars: perUserMonthlyLimitDollars,
-                perUserOnDemandLimitDollars: perUserOnDemandLimitDollars)
+                perUserOnDemandLimitDollars: perUserOnDemandLimitDollars,
+                period: try? periodRes.get())
         } else if let usage {
             baseData = UsageDisplayData.from(usage: usage, userInfo: userInfo)
         } else {

--- a/Tests/CursorMeterTests/CircularProgressIconTests.swift
+++ b/Tests/CursorMeterTests/CircularProgressIconTests.swift
@@ -91,6 +91,14 @@ final class CircularProgressIconTests: XCTestCase {
         XCTAssertGreaterThan(image.size.width, 0)
     }
 
+    func testMenuBarImageWithCustomLabelIsWiderThanSinglePercent() {
+        let single = CircularProgressIcon.menuBarImageWithPercent(percent: 32)
+        let dual = CircularProgressIcon.menuBarImageWithPercent(
+            percent: 86, label: "32% · 86%")
+        XCTAssertGreaterThan(dual.size.width, single.size.width)
+        XCTAssertEqual(dual.size.height, 22)
+    }
+
     // MARK: - Login Required Image (#76)
 
     func testLoginRequiredImageIsWiderThanIdle() {

--- a/Tests/CursorMeterTests/CredentialChainTests.swift
+++ b/Tests/CursorMeterTests/CredentialChainTests.swift
@@ -205,6 +205,71 @@ final class CredentialChainTests: XCTestCase {
         XCTAssertFalse(vm.ideAuthSuppressed, "explicit reconnect intent clears suppression")
     }
 
+    /// GitHub-linked IDE sessions 404 `/api/auth/me` ("User not found: '<numeric>'")
+    /// while usage-summary still returns 200. Identity must not fail the refresh.
+    func testAuthMe404DoesNotFailRefreshWhenSummarySucceeds() async {
+        let vm = makeViewModel()
+        vm.ideCredentialProvider = { Self.ideCredential }
+        MockURLProtocol.requestHandler = Self.authMe404Handler()
+
+        await vm.refresh()
+
+        XCTAssertEqual(vm.authState, .loggedIn)
+        XCTAssertEqual(vm.activeAuthSource, .cursorIDE)
+        XCTAssertNotNil(vm.usageData)
+        XCTAssertNil(vm.errorMessage)
+        XCTAssertEqual(vm.usageData?.email, "Unknown")
+    }
+
+    func testAuthMe404UsesIdentityFallbackForDisplay() async {
+        let vm = makeViewModel()
+        vm.ideCredentialProvider = {
+            IDECredential(
+                cookieHeader: Self.ideCredential.cookieHeader,
+                expiresAt: Self.ideCredential.expiresAt,
+                email: "fallback@t.com",
+                name: "Fallback"
+            )
+        }
+        MockURLProtocol.requestHandler = Self.authMe404Handler()
+
+        await vm.refresh()
+
+        XCTAssertEqual(vm.usageData?.email, "fallback@t.com")
+        XCTAssertEqual(vm.usageData?.name, "Fallback")
+        XCTAssertNil(vm.errorMessage)
+    }
+
+    /// When identity AND both usage endpoints fail, the identity 404 still surfaces.
+    func testAuthMe404SurfacesWhenUsageAlsoFails() async {
+        let vm = makeViewModel()
+        vm.ideCredentialProvider = { Self.ideCredential }
+        MockURLProtocol.requestHandler = { request in
+            let url = request.url!
+            return (
+                HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!,
+                Data("not found".utf8)
+            )
+        }
+
+        await vm.refresh()
+
+        XCTAssertNil(vm.usageData)
+        XCTAssertEqual(vm.errorMessage, "Server error (404)")
+    }
+
+    private static func authMe404Handler() -> (URLRequest) throws -> (HTTPURLResponse, Data) {
+        let base = successHandler { _ in }
+        return { request in
+            if request.url!.path == "/api/auth/me" {
+                let notFound = HTTPURLResponse(
+                    url: request.url!, statusCode: 404, httpVersion: nil, headerFields: nil)!
+                return (notFound, Data("Failed to handle profile: User not found".utf8))
+            }
+            return try base(request)
+        }
+    }
+
     func testAccountSwitchResetsPerAccountState() async {
         let vm = makeViewModel()
         vm.ideCredentialProvider = { Self.ideCredential }

--- a/Tests/CursorMeterTests/CurrentPeriodUsageTests.swift
+++ b/Tests/CursorMeterTests/CurrentPeriodUsageTests.swift
@@ -1,0 +1,202 @@
+import XCTest
+@testable import CursorMeter
+
+@MainActor
+final class CurrentPeriodUsageTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: "ideAuthSuppressed")
+    }
+
+    override func tearDown() {
+        MockURLProtocol.requestHandler = nil
+        UserDefaults.standard.removeObject(forKey: "ideAuthSuppressed")
+        super.tearDown()
+    }
+
+    private let ultraJSON = """
+    {
+        "billingCycleStart": "1787312054000",
+        "billingCycleEnd": "1789990454000",
+        "planUsage": {
+            "totalSpend": 138473,
+            "includedSpend": 40000,
+            "bonusSpend": 98473,
+            "limit": 40000,
+            "remainingBonus": false,
+            "autoPercentUsed": 31.883333333333336,
+            "apiPercentUsed": 85.646,
+            "totalPercentUsed": 39.56371428571428
+        },
+        "spendLimitUsage": { "limitType": "user" },
+        "enabled": true,
+        "autoModelSelectedDisplayMessage": "You've used 40% of your included total usage",
+        "namedModelSelectedDisplayMessage": "You've used 86% of your included API usage"
+    }
+    """
+
+    func testDecodeUltraPayload() throws {
+        let decoded = try JSONDecoder().decode(
+            CurrentPeriodUsageResponse.self, from: Data(ultraJSON.utf8))
+        XCTAssertEqual(decoded.planUsage?.autoPercentUsed ?? 0, 31.8833, accuracy: 0.001)
+        XCTAssertEqual(decoded.planUsage?.apiPercentUsed ?? 0, 85.646, accuracy: 0.001)
+        XCTAssertEqual(decoded.planUsage?.totalPercentUsed ?? 0, 39.5637, accuracy: 0.001)
+    }
+
+    func testDecodeMissingPlanUsage() throws {
+        let decoded = try JSONDecoder().decode(
+            CurrentPeriodUsageResponse.self, from: Data("{}".utf8))
+        XCTAssertNil(decoded.planUsage)
+    }
+
+    func testFetchSendsPostWithOriginAndEmptyBody() async throws {
+        final class RequestBox: @unchecked Sendable {
+            var method: String?
+            var origin: String?
+            var path: String?
+        }
+        let box = RequestBox()
+        MockURLProtocol.requestHandler = { request in
+            box.method = request.httpMethod
+            box.origin = request.value(forHTTPHeaderField: "Origin")
+            box.path = request.url?.path
+            let ok = HTTPURLResponse(
+                url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (ok, Data(#"{"planUsage":{"autoPercentUsed":1,"apiPercentUsed":2,"totalPercentUsed":1.5}}"#.utf8))
+        }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let client = CursorAPIClient(configuration: config)
+
+        let result = try await client.fetchCurrentPeriodUsage(cookieHeader: "session=x")
+
+        XCTAssertEqual(box.method, "POST")
+        XCTAssertEqual(box.origin, "https://cursor.com")
+        XCTAssertEqual(box.path, "/api/dashboard/get-current-period-usage")
+        XCTAssertEqual(result.planUsage?.autoPercentUsed, 1)
+        MockURLProtocol.requestHandler = nil
+    }
+
+    func testFromSummaryPrefersPeriodPercentsOverPlan() {
+        let summary = UsageSummaryResponse(
+            billingCycleStart: "2026-08-21T11:34:14.000Z",
+            billingCycleEnd: "2026-09-21T11:34:14.000Z",
+            membershipType: "ultra",
+            limitType: "user",
+            isUnlimited: false,
+            autoModelSelectedDisplayMessage: nil,
+            individualUsage: IndividualUsage(
+                plan: PlanUsage(
+                    enabled: true, used: 400, limit: 400,
+                    remaining: 0, totalPercentUsed: 10,
+                    autoPercentUsed: 10, apiPercentUsed: 10),
+                onDemand: nil, overall: nil),
+            teamUsage: nil
+        )
+        let period = CurrentPeriodUsageResponse(
+            planUsage: CurrentPeriodPlanUsage(
+                autoPercentUsed: 31.88, apiPercentUsed: 85.65, totalPercentUsed: 39.56)
+        )
+        let data = UsageDisplayData.from(
+            summary: summary, usage: nil,
+            userInfo: UserInfoResponse(email: "t@t.com", name: "T"),
+            period: period
+        )
+        XCTAssertEqual(data.cursorModelsPercent ?? 0, 31.88, accuracy: 0.01)
+        XCTAssertEqual(data.otherModelsPercent ?? 0, 85.65, accuracy: 0.01)
+        XCTAssertTrue(data.hasBucketMeters)
+        XCTAssertEqual(data.percentUsed, 39.56, accuracy: 0.01)
+        XCTAssertEqual(data.percentText, "40%")
+        XCTAssertEqual(data.usageLabel, "Cursor 32%")
+        XCTAssertEqual(data.usageText, "Other 86%")
+        XCTAssertEqual(data.menuBarBucketText, "32% · 86%")
+        XCTAssertEqual(data.menuBarRingPercent, 85.65, accuracy: 0.01)
+    }
+
+    func testFromSummaryFallsBackToPlanBucketPercents() {
+        let summary = UsageSummaryResponse(
+            billingCycleStart: nil,
+            billingCycleEnd: "2026-09-21T11:34:14.000Z",
+            membershipType: "ultra",
+            limitType: nil,
+            isUnlimited: nil,
+            autoModelSelectedDisplayMessage: nil,
+            individualUsage: IndividualUsage(
+                plan: PlanUsage(
+                    enabled: true, used: 0, limit: 40000,
+                    remaining: 0, totalPercentUsed: 39.56,
+                    autoPercentUsed: 31.88, apiPercentUsed: 85.65),
+                onDemand: nil, overall: nil),
+            teamUsage: nil
+        )
+        let data = UsageDisplayData.from(
+            summary: summary, usage: nil,
+            userInfo: UserInfoResponse(email: "t@t.com", name: "T")
+        )
+        XCTAssertTrue(data.hasBucketMeters)
+        XCTAssertEqual(data.percentUsed, 39.56, accuracy: 0.01)
+        XCTAssertEqual(data.cursorModelsPercent ?? 0, 31.88, accuracy: 0.01)
+    }
+
+    func testCreditPlanWithoutBucketsStillUsesCentsRatio() {
+        let data = UsageDisplayData(
+            email: "t@t.com", name: "T", membershipType: "pro",
+            planUsedCents: 800, planLimitCents: 2000, serverPercentUsed: 3,
+            requestsUsed: 0, requestsLimit: 0,
+            onDemandUsedCents: nil, onDemandLimitCents: nil,
+            onDemandEnabled: nil, isOnDemandActive: false,
+            cycleStartDate: nil, resetDate: nil
+        )
+        XCTAssertFalse(data.hasBucketMeters)
+        XCTAssertEqual(data.percentUsed, 40.0, accuracy: 0.01)
+    }
+
+    func testRefreshAppliesPeriodUsageWhenAuthMe404s() async {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let vm = UsageViewModel(apiClient: CursorAPIClient(configuration: config))
+        vm.keychainDeleteHandler = {}
+        vm.sessionExpiredNotifier = {}
+        vm.updateCheckRunner = { .upToDate }
+        vm.ideCredentialProvider = {
+            IDECredential(
+                cookieHeader: "WorkosCursorSessionToken=ide",
+                expiresAt: Date().addingTimeInterval(3600)
+            )
+        }
+        MockURLProtocol.requestHandler = { request in
+            let url = request.url!
+            let ok = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            switch url.path {
+            case "/api/usage-summary":
+                return (ok, Data("""
+                {"billingCycleStart":"2026-08-21T00:00:00.000Z","billingCycleEnd":"2026-09-21T00:00:00.000Z",
+                 "membershipType":"ultra","individualUsage":{"plan":{"enabled":true,"used":40000,"limit":40000,
+                 "totalPercentUsed":10}}}
+                """.utf8))
+            case "/api/dashboard/get-current-period-usage":
+                return (ok, Data("""
+                {"planUsage":{"autoPercentUsed":31.88,"apiPercentUsed":85.65,"totalPercentUsed":39.56}}
+                """.utf8))
+            case "/api/auth/me":
+                let notFound = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!
+                return (notFound, Data("missing".utf8))
+            case "/api/usage":
+                return (ok, Data("{\"startOfMonth\":\"2026-08-21T00:00:00.000Z\"}".utf8))
+            default:
+                let err = HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)!
+                return (err, Data("{}".utf8))
+            }
+        }
+
+        await vm.refresh()
+        MockURLProtocol.requestHandler = nil
+
+        XCTAssertEqual(vm.authState, .loggedIn)
+        XCTAssertTrue(vm.usageData?.hasBucketMeters == true)
+        XCTAssertEqual(vm.usageData?.percentUsed ?? 0, 39.56, accuracy: 0.01)
+        XCTAssertEqual(vm.usageData?.cursorModelsPercent ?? 0, 31.88, accuracy: 0.01)
+        XCTAssertEqual(vm.usageData?.otherModelsPercent ?? 0, 85.65, accuracy: 0.01)
+    }
+}

--- a/Tests/CursorMeterTests/CursorAppAuthReaderTests.swift
+++ b/Tests/CursorMeterTests/CursorAppAuthReaderTests.swift
@@ -18,7 +18,7 @@ final class CursorAppAuthReaderTests: XCTestCase {
     }
 
     /// Fixture state.vscdb replica in a fresh temp dir. token == nil → row absent.
-    private func makeFixtureDB(token: String?) -> String {
+    private func makeFixtureDB(token: String?, extras: [String: String] = [:]) -> String {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("vscdb-fixture-\(UUID().uuidString)")
         try! FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -30,6 +30,14 @@ final class CursorAppAuthReaderTests: XCTestCase {
             var stmt: OpaquePointer?
             sqlite3_prepare_v2(db, "INSERT INTO ItemTable (key, value) VALUES ('cursorAuth/accessToken', ?)", -1, &stmt, nil)
             sqlite3_bind_text(stmt, 1, token, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            XCTAssertEqual(sqlite3_step(stmt), SQLITE_DONE)
+            sqlite3_finalize(stmt)
+        }
+        for (key, value) in extras {
+            var stmt: OpaquePointer?
+            sqlite3_prepare_v2(db, "INSERT INTO ItemTable (key, value) VALUES (?, ?)", -1, &stmt, nil)
+            sqlite3_bind_text(stmt, 1, key, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 2, value, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
             XCTAssertEqual(sqlite3_step(stmt), SQLITE_DONE)
             sqlite3_finalize(stmt)
         }
@@ -58,7 +66,17 @@ final class CursorAppAuthReaderTests: XCTestCase {
     func testUserIDFromSub() {
         XCTAssertEqual(CursorAppAuthReader.userID(fromSub: "auth0|user_42"), "user_42")
         XCTAssertEqual(CursorAppAuthReader.userID(fromSub: "a|b|user_9"), "user_9")
+        XCTAssertEqual(CursorAppAuthReader.userID(fromSub: "github|18259276"), "18259276")
         XCTAssertNil(CursorAppAuthReader.userID(fromSub: "nopipe"))
+    }
+
+    func testDisplayNameFromProfileJSON() {
+        XCTAssertEqual(
+            CursorAppAuthReader.displayName(fromProfileJSON: #"{"displayName":"Ada"}"#),
+            "Ada")
+        XCTAssertNil(CursorAppAuthReader.displayName(fromProfileJSON: nil))
+        XCTAssertNil(CursorAppAuthReader.displayName(fromProfileJSON: "{}"))
+        XCTAssertNil(CursorAppAuthReader.displayName(fromProfileJSON: #"{"displayName":"  "}"#))
     }
 
     func testMakeCookieHeader() {
@@ -77,6 +95,28 @@ final class CursorAppAuthReaderTests: XCTestCase {
         XCTAssertEqual(cred?.cookieHeader, "WorkosCursorSessionToken=user_01ABC%3A%3A\(jwt)")
         XCTAssertEqual(cred?.expiresAt.timeIntervalSince1970 ?? 0,
                        now.timeIntervalSince1970 + 7200, accuracy: 1)
+        XCTAssertNil(cred?.email)
+        XCTAssertNil(cred?.name)
+    }
+
+    func testReadPicksCachedEmailAndDisplayName() {
+        let jwt = makeJWT(exp: now.timeIntervalSince1970 + 7200)
+        let extras: [String: String] = [
+            "cursorAuth/cachedEmail": "dev@example.com",
+            "cursorAuth/cachedScopedProfile":
+                "{\"displayName\":\"Dev User\",\"pictureUrl\":\"https://example.com/p\"}",
+        ]
+        let reader = CursorAppAuthReader(dbPath: makeFixtureDB(token: jwt, extras: extras))
+        let cred = reader.read(now: now)
+        XCTAssertEqual(cred?.email, "dev@example.com")
+        XCTAssertEqual(cred?.name, "Dev User")
+    }
+
+    func testReadFallsBackToEmailKeyWhenCachedEmailAbsent() {
+        let jwt = makeJWT(exp: now.timeIntervalSince1970 + 7200)
+        let extras = ["cursorAuth/email": "only@example.com"]
+        let reader = CursorAppAuthReader(dbPath: makeFixtureDB(token: jwt, extras: extras))
+        XCTAssertEqual(reader.read(now: now)?.email, "only@example.com")
     }
 
     func testReadRejectsNearExpiredToken() {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -66,6 +66,26 @@ Sole source of `teamId` for the analytics endpoints. Used by `CursorAPIClient.fe
 
 Empty / non-200 on personal plans; observed `{}` (no `teams` key) on a free account 2026-07-24. Personal accounts skip this endpoint entirely for the weekly chart (#103).
 
+### `POST /api/dashboard/get-current-period-usage`
+
+Split included-usage meters for plans that separate Cursor Models vs Other Models (Ultra observed 2026-09-03). Empty JSON body + `Origin: https://cursor.com`. `{"teamId":0}` returns 400 on personal/Ultra.
+
+```json
+{
+  "planUsage": {
+    "autoPercentUsed": 31.88,
+    "apiPercentUsed": 85.65,
+    "totalPercentUsed": 39.56
+  }
+}
+```
+
+- `autoPercentUsed` → popover **Cursor Models** bar (Grok / Composer)
+- `apiPercentUsed` → popover **Other Models** bar
+- `totalPercentUsed` → menu-bar ring / "Included in Ultra" headline percent
+
+When this call fails, CursorMeter falls back to the same three fields on `/api/usage-summary` → `individualUsage.plan` (present on Ultra and some personal plans).
+
 ### `POST /api/dashboard/get-hard-limit`
 
 Member-facing monthly spend limit for token-based enterprise contracts. **Requires `{"teamId": <id>}` in the body** — an empty body returns `{"noUsageBasedAllowed": true}` (all fields nil). Bare-host + `Origin: https://cursor.com` like the other dashboard POSTs.
@@ -150,7 +170,7 @@ Other observed analytics endpoints, all with the same `startDate=/endDate=/teamI
 
 ### Dashboard POST endpoints
 
-Many `/api/dashboard/*` POST endpoints exist (e.g. `get-team-spend`, `get-current-billing-cycle`, `get-hard-limit`, `get-credit-grants-balance`). Not currently planned for use; recorded for future spend/forecast features.
+Many `/api/dashboard/*` POST endpoints exist (e.g. `get-team-spend`, `get-current-billing-cycle`, `get-hard-limit`, `get-credit-grants-balance`). `get-current-period-usage` is now used (see above). The rest are recorded for future spend/forecast features.
 
 ## Known limitations / open questions
 


### PR DESCRIPTION
## TL;DR

<img width="202" height="386" alt="image" src="https://github.com/user-attachments/assets/372c4038-9f56-4ca2-9a58-52d163dbadb6" />


Ultra (and other split-quota) accounts now show **two usage meters** — Cursor Models and Other Models — instead of one combined number. GitHub-signed-in users also stop getting a fake **Server error (404)** on launch.

This is one commit (~700 lines). Most of the new code is tests and display-model fields. No generated files.

## What a user sees

- **Menu bar:** `32% · 86%` next to the ring (Cursor Models · Other Models). The ring color follows the **higher** of the two, so 86% Other Models actually looks like a warning.
- **Popover header:** `Cursor 32%` on the left, `Other 86%` on the right.
- **Popover body:** two bars matching the dashboard (“Includes Cursor Grok and Composer” under Cursor Models).
- Combined `totalPercentUsed` (~40%) is still what notifications use.

## Why the 404 fix is in the same change

GitHub-linked Cursor accounts store `sub` as `github|<numeric id>`. `/api/auth/me` returns **404 User not found** for that cookie, while `/api/usage-summary` and the new period-usage call still return 200. The app used to treat the identity 404 as a hard failure, so the popover never showed usage.

Now: if usage data arrives, a missing `/api/auth/me` is ignored and the name/email come from Cursor’s local cache (`cursorAuth/cachedEmail`, `cachedScopedProfile.displayName`).

## How to review (suggested order)

1. **`Sources/CursorMeter/UsageModels.swift`** — new `CurrentPeriodUsageResponse`, bucket percent fields, header/menu-bar strings. This is the contract.
2. **`Sources/CursorMeter/CursorAPIClient.swift`** — one new POST: `/api/dashboard/get-current-period-usage` with empty `{}` and `Origin: https://cursor.com`. (`{"teamId":0}` 400s on personal/Ultra.)
3. **`Sources/CursorMeter/UsageViewModel.swift`** — fetches period usage in parallel; does not fail the refresh when `/api/auth/me` 404s if summary/usage succeeded.
4. **`Sources/CursorMeter/CursorAppAuthReader.swift`** — reads cached email/name from the IDE DB (same read-only SQLite path as before).
5. **`Sources/CursorMeter/MenuBarView.swift`**, **`CircularProgressIcon.swift`**, **`CursorMeterApp.swift`** — UI only.
6. **Tests** — start with `CurrentPeriodUsageTests.swift`.

Docs-only: `docs/API_REFERENCE.md`, one line in `CLAUDE.md`.

## Risk

- **Identity is optional.** A 401/204 on `/api/auth/me` still expires the session (existing path). Only 404-with-working-usage degrades.
- **New undocumented endpoint.** If it disappears, we fall back to the same three percents on `/api/usage-summary` → `individualUsage.plan` (already present on Ultra).
- **Menu-bar width.** Dual percent text is wider than `40%`. Icon-only mode is unchanged.
- No Keychain / cookie-format change. No auto-update / install-script change.

## Test plan

- [x] `swift test` — 480 tests, 0 failures
- [ ] Ultra account: popover shows Cursor + Other bars and header percents
- [ ] Menu bar (Percent mode): `32% · 86%` (or your live numbers)
- [ ] GitHub-signed Cursor IDE: no more Server error (404); usage appears
- [ ] Non-Ultra / request-based plan: still the single bar and old labels
- [ ] On-demand latch: still the single on-demand bar, not the dual meters

## Out of scope

- Long dashboard footnotes (“Additional usage beyond limits…”)
- Screenshot refresh for `docs/screenshots/`
- Commit split (one commit on purpose; say if you want schema / logic / UI / tests as separate commits)


Made with [Cursor](https://cursor.com)